### PR TITLE
Fixing a warning in PHP 8.1

### DIFF
--- a/src/PerlinNoiseGenerator.php
+++ b/src/PerlinNoiseGenerator.php
@@ -146,7 +146,7 @@ class PerlinNoiseGenerator
             throw new LogicException('Size must be set');
         }
 
-        mt_srand($this->numericMapSeed * $this->persistence * $this->size);
+        mt_srand((int)($this->numericMapSeed * $this->persistence * $this->size));
 
         $this->terra = new SplFixedArray($this->size);
         for ($y = 0; $y < $this->size; $y++) {


### PR DESCRIPTION
Fixes an annoying warning in PHP 8.1 when persistence is not an integer.